### PR TITLE
feat: add route GET /api/chat/:room_id

### DIFF
--- a/controllers/chatController.js
+++ b/controllers/chatController.js
@@ -10,6 +10,15 @@ const chatController = {
     }
   },
 
+  getPrivateChat: async (req, res, next) => {
+    try {
+      const data = await chatService.getHistoryChat(req.params.room_id)
+      return res.json(data)
+    } catch (error) {
+      next(error)
+    }
+  },
+
   getPrivateChatList: async (req, res, next) => {
     try {
       const data = await chatService.getPrivateChatList(req.user.id)

--- a/models/chat.js
+++ b/models/chat.js
@@ -17,7 +17,7 @@ module.exports = (sequelize, DataTypes) => {
   Chat.init({
     UserId: DataTypes.INTEGER,
     text: DataTypes.STRING,
-    room: DataTypes.STRING
+    RoomId: DataTypes.INTEGER
   }, {
     sequelize,
     modelName: 'Chat'

--- a/routes/apis/chatRoute.js
+++ b/routes/apis/chatRoute.js
@@ -5,5 +5,6 @@ const chatController = require('../../controllers/chatController')
 
 router.get('/', chatController.getHistoryChat)
 router.get('/private', chatController.getPrivateChatList)
+router.get('/:room_id', chatController.getPrivateChat)
 
 module.exports = router

--- a/services/chatService.js
+++ b/services/chatService.js
@@ -23,7 +23,7 @@ const chatService = {
   getPrivateChatList: async (currentId, targetId = null) => {
     const target = targetId ? `AND userId = ${targetId}` : ''
     return await await sequelize.query(
-      `SELECT data.id As RoomId, data.name As RoomName, Users.id, Users.name, Users.avatar FROM
+      `SELECT data.id As RoomId, data.name As RoomName, Users.id, Users.name, Users.avatar, CONCAT('@', Users.account) AS account FROM
       (SELECT Room.id, Room.name, COUNT(Members.id) OVER(partition by RoomId) AS people,
       Members.UserId AS userId,
       Members.createdAt AS MembersCreatedAt,


### PR DESCRIPTION
- 新增路由，提供前端抓取歷史訊息的 API
- 新增 account 欄位，以因應前端需求：
  - 私訊名單 API `getPrivateChatList`
  - 取得使用者資料 `socketAuth`
- 更改 chat model 的 RoomId 欄位 (STRING -> INTEGER)
- 更改 socket io 的 cors 相關設定，使用環境變數來帶入似乎不太穩定，暫時採取 hardcode 的形式
- 更改 socket io 儲存使用者名單的資料型態 (WeakSet -> Array)，避免前端無法顯示使用者名單。
- 新增 socket io 事件 `privateMessage`